### PR TITLE
Explicitly encode to UTF-8

### DIFF
--- a/scripts/startup
+++ b/scripts/startup
@@ -86,7 +86,8 @@ def export_encoded_cacertificates():
     certificate_authorities_base64 = os.environ.get('CERTIFICATE_AUTHORITIES_BASE64')
     if certificate_authorities_base64 is not None:
         logging.info("Decoding encoded CA certificates into CERTIFICATE_AUTHORITIES environment variable")
-        os.environ['CERTIFICATE_AUTHORITIES'] = str(base64.b64decode(certificate_authorities_base64))
+        certificate_authorities = base64.b64decode(certificate_authorities_base64)
+        os.environ['CERTIFICATE_AUTHORITIES'] = str(certificate_authorities,'utf-8')
             
 def call_builpack_startup():
     logging.debug("Executing call_builpack_startup...")


### PR DESCRIPTION
Explicitly encode certificate file to UTF-8, to prevent:
mendixapp_1  | ERROR: Starting app container failed: Traceback (most recent call last):
mendixapp_1  |   File "/buildpack/start.py", line 1053, in <module>
mendixapp_1  |     complete_start_procedure_safe_to_use_for_restart(m2ee)
mendixapp_1  |   File "/buildpack/start.py", line 1011, in complete_start_procedure_safe_to_use_for_restart
mendixapp_1  |     start_app(m2ee)
mendixapp_1  |   File "/buildpack/start.py", line 797, in start_app
mendixapp_1  |     if not m2ee.send_runtime_config():
mendixapp_1  |   File "lib/m2ee/core.py", line 269, in send_runtime_config
mendixapp_1  |     m2eeresponse = self.client.update_configuration(config)
mendixapp_1  |   File "lib/m2ee/client.py", line 136, in update_configuration
mendixapp_1  |     return self.request("update_configuration", params)
mendixapp_1  |   File "lib/m2ee/client.py", line 53, in request
mendixapp_1  |     return M2EEResponse(action, json.loads(response_body.decode('utf-8')))
mendixapp_1  |   File "/usr/lib/python3.4/json/__init__.py", line 318, in loads
mendixapp_1  |     return _default_decoder.decode(s)
mendixapp_1  |   File "/usr/lib/python3.4/json/decoder.py", line 343, in decode
mendixapp_1  |     obj, end = self.raw_decode(s, idx=_w(s, 0).end())
mendixapp_1  |   File "/usr/lib/python3.4/json/decoder.py", line 361, in raw_decode
mendixapp_1  |     raise ValueError(errmsg("Expecting value", s, err.value)) from None
mendixapp_1  | ValueError: Expecting value: line 1 column 1 (char 0)